### PR TITLE
Fix the alignment issue #4

### DIFF
--- a/src/js/jquery-calendar.js
+++ b/src/js/jquery-calendar.js
@@ -341,7 +341,8 @@ jQuery(document).ready(function($){
     $(this.element).find('div.calendar-timeline').css('padding-top', this.conf.weekday.dayline.heightPx+'px');
     var marginTop = this.conf.weekday.dayline.month.heightPx;
     if (this.conf.categories.enable){
-      marginTop += 30;
+      var $categoryBar = $(this.element).find('div.calendar-categories');
+      marginTop += $categoryBar.height() + parseFloat($categoryBar.css('margin-bottom'));
     }
     $(this.element).find('div.calendar-timeline').css('margin-top', marginTop+'px');
 
@@ -438,6 +439,12 @@ jQuery(document).ready(function($){
     $(this.element).find('.calendar-day-header').each(function(){
       $(this).height(maxHeight);
     });
+
+    if (this.conf.weekday.dayline.heightPx < maxHeight) {
+      this.conf.weekday.dayline.heightPx = maxHeight;
+      $(this.element).find('div.calendar-timeline').css('padding-top', this.conf.weekday.dayline.heightPx + 'px');    // W: Padding-top do cabeçalho dos dias da semana
+      // alert(this.conf.weekday.dayline.heightPx + " " + $(this.element).find('.calendar-day-header').first().css('height'));
+    }
   };
 
   Calendar.prototype.monthDrawWeek = function() {


### PR DESCRIPTION
PART 1)
The problem is because the height of the `div.calendar-day-header` element is edit (increased) after creating the timeline (`div.calendar-timeline`) which uses this height value as its `padding-top` property so the timeline can be aligned with the events boxes. 
*I tried to fix this problem in the lines 442 to 447.*

PART 2)
The height and margin of the categories bar (`div.calendar-categories`) is not accurately considered as `margin-top` of the timeline (`div.calendar-timeline`)  in line 344 which causes the miss alignment too. Therefore, I tried to fix this problem getting the `height` and `margin-bottom` of  the categories bar dynamicaly in the lines 344 and 345 so the `margin-top` property of the timeline will equal to the correct value and the timeline grid will be correctly positioned relatively to the event boxes.

With those code lines, I believe the issue is fixed.